### PR TITLE
Monkey patch the search function and default filter for meetings

### DIFF
--- a/app/views/layouts/decidim/meetings/meetings/_filters.html.erb
+++ b/app/views/layouts/decidim/meetings/meetings/_filters.html.erb
@@ -1,0 +1,26 @@
+<%= filter_form_for filter do |form| %>
+  <div class="filters__section">
+    <div class="filters__search">
+      <div class="input-group">
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search") %>
+        <div class="input-group-button">
+          <button type="submit" class="button button--muted">
+            <%= icon "magnifying-glass", aria_label: t(".search") %>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% unless @forced_past_meetings %>
+    <%= form.collection_radio_buttons :date, [["all", t(".all")], ["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
+  <% end %>
+
+  <% if current_participatory_space.has_subscopes? %>
+    <%= scopes_picker_filter form, :scope_id %>
+  <% end %>
+
+  <% if current_component.categories.any? %>
+    <%= form.categories_select :category_id, current_component.categories, legend_title: t(".category"), disable_parents: false, label: false, prompt: t(".category_prompt") %>
+  <% end %>
+<% end %>

--- a/config/initializers/monkey-patch/decidim-meetings/controllers/decidim/meetings/meetings_controller.rb
+++ b/config/initializers/monkey-patch/decidim-meetings/controllers/decidim/meetings/meetings_controller.rb
@@ -1,0 +1,12 @@
+Decidim::Meetings::MeetingsController.class_eval do
+  private
+
+  def default_filter_params
+    {
+      date: "all",
+      search_text: "",
+      scope_id: "",
+      category_id: ""
+    }
+  end
+end

--- a/config/initializers/monkey-patch/decidim-meetings/services/decidim/meetings/meeting_search.rb
+++ b/config/initializers/monkey-patch/decidim-meetings/services/decidim/meetings/meeting_search.rb
@@ -1,0 +1,11 @@
+Decidim::Meetings::MeetingSearch.class_eval do
+  def search_date
+    if options[:date] == "upcoming"
+      query.where("end_time >= ? ", Time.current).order(start_time: :asc)
+    elsif options[:date] == "past"
+      query.where("end_time <= ? ", Time.current).order(start_time: :desc)
+    else # Assume 'all'
+      query
+    end
+  end
+end

--- a/config/locales/en-meetings.yml
+++ b/config/locales/en-meetings.yml
@@ -1,0 +1,37 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   'true': 'foo'
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+en:
+  decidim:
+    meetings:
+      meetings:
+        filters:
+          all: All

--- a/config/locales/fr-meetings.yml
+++ b/config/locales/fr-meetings.yml
@@ -1,0 +1,37 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   'true': 'foo'
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+fr:
+  decidim:
+    meetings:
+      meetings:
+        filters:
+          all: Toutes


### PR DESCRIPTION
#### :tophat: What? Why?

Adds an "All" option to the date filter on the meeting list page and defaults to it on page load.

### :camera: Screenshots (optional)
![Capture d’écran 2020-01-10 à 19 11 23](https://user-images.githubusercontent.com/7223028/72175762-3351a880-33dd-11ea-9939-169b4240d5a8.png)

